### PR TITLE
on the marke -> on the market

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Leosac setup is usually composed of an embedded Linux board running the softwa
 * Multiple-door/reader support
 * Ethernet connectivity
 * **Fully** configurable wiring layout
-* Portable on virtually every Linux devices on the marke
+* Portable on virtually every Linux devices on the market
 * Open-source
 
 


### PR DESCRIPTION
Trival typo fix