### PR TITLE
Update Debian Packaging to build develop

### DIFF
--- a/deb.sh
+++ b/deb.sh
@@ -3,8 +3,11 @@
 # This script generate debian package for Leosac.
 #
 
-TMP_DIR=$(mktemp -d)
+#
+# SUBROUTINES
+#
 
+# Unused function
 function die()
 {
     if [ -z $1 ]; then
@@ -16,21 +19,76 @@ function die()
     rm -rf $TMP_DIR
     exit $1
 }
-cd $TMP_DIR
-
-echo $TMP_DIR
 
 function clone()
 {
-    git clone https://github.com/leosac/leosac.git
+    git clone $1
     pushd leosac
-    git checkout master;
+    git checkout $2;
     git submodule init;
     git submodule update;
     popd
 }
 
-clone
+usage()
+{
+cat <<EOF
+
+Usage: $0 [-h] [-u GIT REPO ] [-b GIT BRANCH ]
+
+OPTIONS:
+   -h      Show this message and quit
+   -u      Full url to a Leosac git repo
+   -b      Git branch name to checkout
+
+EOF
+}
+
+#
+# BEGIN MAIN PROGRAM
+#
+
+# Set default values
+url="https://github.com/leosac/leosac.git"
+branch="develop"
+
+while getopts "hu:b:" OPTION
+do
+     case $OPTION in
+         h)
+             usage
+             exit 0
+             ;;
+         u)
+             url="$OPTARG"
+             ;;
+         b)
+             branch="$OPTARG"
+             ;;
+         *)
+             usage
+             exit 50
+             ;;
+     esac
+done
+
+# Check to see if this script has access to all the commands it needs
+for CMD in cp debuild egrep git grep mk-build-deps mv sudo tar; do
+  type $CMD 2>&1 > /dev/null
+
+  if [ $? -ne 0 ]; then
+    echo
+    echo "ERROR: The script cannot find the required command \"${CMD}\"."
+    echo
+    exit 99
+  fi
+done
+
+TMP_DIR=$(mktemp -d)
+cd $TMP_DIR
+echo $TMP_DIR
+
+clone $url $branch
 
 MAJOR=`grep "DLEOSAC_VERSION_MAJOR=" leosac/CMakeLists.txt | egrep -o '([0-9]+)'`
 MINOR=`grep "DLEOSAC_VERSION_MINOR=" leosac/CMakeLists.txt | egrep -o '([0-9]+)'`
@@ -46,7 +104,20 @@ cd $name
 #copy existing pkg/debian directory (maintained in repos, with patches)
 cp -R pkg/debian .
 
+# Auto-install build dependencies using the debian control file
+sudo mk-build-deps -ir ./debian/control
+
 if [ -z ${DEB_BUILD_OPTIONS} ] ; then
     export DEB_BUILD_OPTIONS="parallel=3"
 fi
 debuild -us -uc
+
+RESULT="$?"
+
+if [ "$RESULT" == "0" ]; then
+    echo
+    echo "The build succeeded."
+    echo "Debian package files can be found here: ${TMP_DIR}"
+    echo
+fi
+

--- a/doc/guides/guide_install_from_package.md
+++ b/doc/guides/guide_install_from_package.md
@@ -1,0 +1,56 @@
+@page page_guide_install_from_package Building Leosac
+
+@brief Describe how to build and install a Leosac deb package.
+
+Target platform
+---------------
+
+This guide is intended to be used on Debian Stretch with amd64 architecture or Raspbian Stretch with armv6/armv7 architecture.
+
+Dependencies
+------------
+
+For starters, install these packages:
+```
+apt-get install cmake build-essential git sudo devscripts
+```
+
+There is a bug in the ODB compiler found in the Debian and Raspbian repos, which prevents Leosac from building.
+A bug report has been filed. See [#889664](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=889664).
+Until this has been resolved and new pacakges are pushed out to the Debian and Raspbian repos, one must use the odb packages in the Leosac bin-resources repo instead.
+
+The following steps were performed on a Raspberry PI running Stretch with gcc 6.4 installed.
+The folder you choose may differ from this example. Choose the appropriate subfolder names which match your architecture and version of gcc.
+```
+git clone https://github.com/leosac/bin-resources
+cd bin-resources/debian/gcc6.4/armhf
+sudo dpkg -i *.deb
+```
+
+There are additional dependencies required to build Leosac, but those will be installed for you by the deb.sh script.
+
+Build
+-----
+
+Get the Leosac Debian packaging script and mark it executable:
+```
+wget https://raw.githubusercontent.com/leosac/leosac/develop/deb.sh
+chmod +x deb.sh
+```
+
+If you intend to build the very latest code from the develop branch, then simply call deb.sh with no parameters to start the build process:
+```
+./deb.sh
+```
+
+If instead you prefer to build the latest release (or some other branch), then use the -b flag to specify the branch, tag, or release to build:
+```
+./deb.sh -b v0.7.0
+```
+
+Replace "v0.70" with the tag name of the most recent release, found on the leosac releases page.
+
+That's it!
+When the build completes, it will present the name of the folder, under /tmp, where the newly built package files reside.
+From the command line, navigate to that folder and install the Leosac debian package file using dpkg -i or gdebi.
+

--- a/doc/guides/guides.md
+++ b/doc/guides/guides.md
@@ -4,4 +4,5 @@ This page references guides:
   * @subpage page_guide_cli
   * @subpage page_guide_docker_amd64
   * @subpage page_guide_install_from_source
+  * @subpage page_guide_install_from_package
   * @subpage page_guide_docker_cc

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -6,6 +6,7 @@ Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 9),
                cmake,
                default-libmysqlclient-dev | libmysqlclient-dev,
+               g++ (>= 5),
                libtclap-dev,
                libboost-date-time-dev,
                libboost-filesystem-dev,
@@ -23,7 +24,12 @@ Build-Depends: debhelper (>= 9),
                libpython2.7-dev,
                libunwind-dev,
                libzmq3-dev,
-               g++ (>= 5)
+               libodb-dev,
+               libodb-boost-dev,
+               libodb-mysql-dev,
+               libodb-pgsql-dev,
+               libodb-sqlite-dev,
+               odb
 
 Package: leosac
 Architecture: any

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -3,7 +3,27 @@ Maintainer: Arnaud Kapp <kapp.arno@gmail.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), cmake, libtclap-dev, libboost-serialization-dev, g++ (>= 4.8)
+Build-Depends: debhelper (>= 9),
+               cmake,
+               default-libmysqlclient-dev | libmysqlclient-dev,
+               libtclap-dev,
+               libboost-date-time-dev,
+               libboost-filesystem-dev,
+               libboost-regex-dev,
+               libboost-serialization-dev,
+               libboost-system-dev,
+               libcurl4-openssl-dev,
+               libgtest-dev,
+               libpq-dev,
+               libpython2.7-dev,
+               libscrypt-dev,
+               libsqlite3-dev,
+               libsodium-dev,
+               libssl-dev,
+               libpython2.7-dev,
+               libunwind-dev,
+               libzmq3-dev,
+               g++ (>= 5)
 
 Package: leosac
 Architecture: any

--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -11,12 +11,9 @@ override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DLEOSAC_PLATFORM=None -DCMAKE_BUILD_TYPE=Release \
-	 -DZMQ_BUILD_TESTS=0 -DZMQPP_BUILD_STATIC=0 \
-	-DZMQPP_LIBZMQ_CMAKE=1 \
-	-DZEROMQ_LIB_DIR=`pwd`/libzmq/.libs/ \
-        -DZEROMQ_INCLUDE_DIR=`pwd`/libzmq/include
-
+	dh_auto_configure -- \
+            -DCMAKE_BUILD_TYPE=Release \
+            ..
 
 override_dh_auto_install:
 	dh_auto_install


### PR DESCRIPTION
These changes allow the deb.sh script to build the latest develop branch, or another leosac branch or fork.

Documentation is included, but I do not know how to preview my additions. I expect further changes to be required, once I can see the page rendered to html.

TO-DO:
Add custom built odb packages to the Leosac bin-resources repo. I'll have a separate pr for that once I've got the packages ready.