### PR TITLE
additional documentation updates

### DIFF
--- a/doc/guides/guide_docker_cc.md
+++ b/doc/guides/guide_docker_cc.md
@@ -9,7 +9,7 @@ The process of cross-compilation builds, then bundles, all dependencies.
 Background
 ----------
 
-This method trades simplicity for speed. If watching your Pi take hours to build Leosac is not your idea of fun, then you should consider this method to build Leosac.
+This method trades simplicity for speed. If your idea of fun is not watching your Pi take hours to build Leosac, then you should consider this method to build Leosac.
 
 The recommended way to interact with the cross-compile container is to use `leosaccli dev cc XXX`. 
 This tool must be built first, however, and the steps below explain how to do that.
@@ -34,16 +34,8 @@ This will create a set of files in an aribtrary folder under /tmp. This folder w
 Prerequsites
 ------------
 
-Before cross-compiling Leosac, the "cross_compile" container must be built.
-
-@note Prior to following these steps, [Docker](https://docs.docker.com/get-started/) must be installed, and you must be able to run Docker as a non-root user.
-
-Perform these steps to build the cross-compile container:
-  + Clone the Leosac bin-resources repository: `git clone http://github.com/leosac/bin-resources`
-  + Move the the `cross-compile-resources` subfolder into the root of the Leosac repository
-  + Now build the container with `leosaccli dev docker build cross_compile`.
-
-@note Building the container *does not* build Leosac. Instead, it builds and install its dependencies and required toolchain.
+Prior to following the steps below, [Docker](https://docs.docker.com/get-started/) must be installed, and you must be able to run Docker as a non-root user.
+Verify Docker is working currently by running the "Hello World" container as shown in the [Get-Started](https://docs.docker.com/get-started/) guide.
 
 
 Full Example from Start to Finish
@@ -66,6 +58,8 @@ Build the leosaccli tool:
 
 Build the cross-compile container:
   + `leosaccli dev docker build cross_compile`
+
+@note Building the cross-compile container *does not* build Leosac. Instead, it builds and install its dependencies and required toolchain.
   
 Cross-compile Leosac:
   + `leosaccli dev cc cmake`
@@ -86,12 +80,14 @@ After copying the files to the target machine, log in and unpack the files:
 Follow-Up Tasks
 ---------------
 
-Leosac is now installed on your system, but there are couple of additonal tasks you should perform for the best experience.
+Leosac is now installed on your system, but there are couple of additional tasks you should perform.
 
-Copy the Leosac init script into place so it can be started as a service:
-  + `wget https://raw.githubusercontent.com/leosac/leosac/develop/pkg/deb/leosacd`
-  + `sed -i 's/\/usr\/bin\/leosac/\/usr\/local\/bin\/leosac/g' pkg/deb/leosacd`
-  + `sudo install -m 755 -t "/etc/init.d" "leosacd"`
+Get the Leosac service file:
+  + `https://raw.githubusercontent.com/leosac/leosac/develop/pkg/debian/leosac.service`
 
-Create a kernel.xml file (see the [installation guide](@ref page_guide_rpi_piface_wiegand)) and copy it to /etc/leosac.d.
-  + `sudo install -m 755 -d "/etc/leosac.d"`
+Edit the leosac service file, changing `/usr/bin/leosac` to `/usr/local/bin/leosac`, then copy it into place:
+  + `vi/gedit leosac.service`
+  + `sudo cp leosac.service /etc/systemd/system`
+
+Finally, before you can start Leosac, you need to create a kernel.xml file. See the [installation guide](@ref page_guide_rpi_piface_wiegand).
+

--- a/doc/guides/guide_install_from_package.md
+++ b/doc/guides/guide_install_from_package.md
@@ -2,55 +2,57 @@
 
 @brief Describe how to build and install a Leosac deb package.
 
-Target platform
----------------
+
+Background
+----------
 
 This guide is intended to be used on Debian Stretch with amd64 architecture or Raspbian Stretch with armv6/armv7 architecture.
+The process desibed here is a straightforward and relatively simple approach to building and installing Leosac on the native hardware.
+It does this at the expense of speed. The build process described here will take several hours to complete on a modern Raspberry Pi, and will take around 12 hours or more to complete on the model 1 Pi's and the Zero.
+Consider using one of the other build methods if build time is important.
+
 
 Dependencies
 ------------
 
 For starters, install these packages:
-```
-apt-get install cmake build-essential git sudo devscripts
-```
+  + `apt-get install cmake build-essential git sudo devscripts`
 
-There is a bug in the ODB compiler found in the Debian and Raspbian repos, which prevents Leosac from building.
-A bug report has been filed. See [#889664](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=889664).
-Until this has been resolved and new pacakges are pushed out to the Debian and Raspbian repos, one must use the odb packages in the Leosac bin-resources repo instead.
+@note The ODB package in the Debian & Raspbian repositories is broken. A bug report has been filed. See [889664](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=889664). Until this is resolved, a set of patched odb packages have been made available in the Leosac [bin-resources](https://github.com/leosac/bin-resources) repository.
 
-The following steps were performed on a Raspberry PI running Stretch with gcc 6.4 installed.
-The folder you choose may differ from this example. Choose the appropriate subfolder names which match your architecture and version of gcc.
-```
-git clone https://github.com/leosac/bin-resources
-cd bin-resources/debian/gcc6.4/armhf
-sudo dpkg -i *.deb
-```
+The following steps assume the odb package is not already installed on the target system. If it is, uninstall it first.
+  + `git clone https://github.com/leosac/bin-resources`
+  + `cd bin-resources/debian/gcc6/amd64`
+  + `sudo dpkg -i odb_2.4.0*.deb`
+  + `sudo apt-mark hold odb`
+  + `sudo apt-get install -f`
 
+If running Raspbian, replace amd64 in the folder name shown above with armhf.
 There are additional dependencies required to build Leosac, but those will be installed for you by the deb.sh script.
+
 
 Build
 -----
 
 Get the Leosac Debian packaging script and mark it executable:
-```
-wget https://raw.githubusercontent.com/leosac/leosac/develop/deb.sh
-chmod +x deb.sh
-```
+  + `wget https://raw.githubusercontent.com/leosac/leosac/develop/deb.sh`
+  + `chmod +x deb.sh`
 
 If you intend to build the very latest code from the develop branch, then simply call deb.sh with no parameters to start the build process:
-```
-./deb.sh
-```
+  + `./deb.sh`
 
 If instead you prefer to build the latest release (or some other branch), then use the -b flag to specify the branch, tag, or release to build:
-```
-./deb.sh -b v0.7.0
-```
+  + `./deb.sh -b v0.7.0`
 
-Replace "v0.70" with the tag name of the most recent release, found on the leosac releases page.
+Replace "v0.70" with the tag name of the most recent release, found on the leosac [releases page](https://github.com/leosac/leosac/releases).
 
-That's it!
-When the build completes, it will present the name of the folder, under /tmp, where the newly built package files reside.
+Let's say you have development work in a branch in your own fork you want to test, you can call deb.sh this way:
+  + `./deb.sh -u https://github.com/your-git-profile/leosac -b your-branch` 
+
+When the build completes, it will present the name of any arbitrary folder under /tmp where the newly built package files reside.
 From the command line, navigate to that folder and install the Leosac debian package file using dpkg -i or gdebi.
+  + `cd /tmp/some-random-name`
+  + `sudo gdebi leosac_0.7.0-1_amd64.deb`
+
+Leosac is now installed, but before you can start it, you need to create a kernel.xml file. See the [installation guide](@ref page_guide_rpi_piface_wiegand).
 

--- a/doc/guides/guide_install_from_source.md
+++ b/doc/guides/guide_install_from_source.md
@@ -3,63 +3,63 @@
 @brief Describe how to build Leosac from source.
 
 
-Target platform
----------------
+Background
+----------
 
 This guide is intended to be used on Debian Stretch with amd64 architecture or Raspbian Stretch with armv6/armv7 architecture.
+While not quite as slow as building Leosac into a deb package, this method can still takes hours to complete when building natively on a Raspberry Pi.
+
 
 Dependencies
 ------------
 
-Leosac has a number of dependencies that need to be installed:
+@note The ODB package from the Debian & Raspbian repositories is broken. A bug report has been filed. See [889664](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=889664). Until this is resolved, a set of patched odb packages have been made available in the Leosac [bin-resources](https://github.com/leosac/bin-resources) repository.
+
+The following steps assume the odb package is not already installed on the target system. If it is, uninstall it first.
+  + `git clone https://github.com/leosac/bin-resources`
+  + `cd bin-resources/debian/gcc6/armhf`
+  + `sudo dpkg -i odb_2.4.0*.deb`
+  + `sudo apt-mark hold odb`
+  + `sudo apt-get install -f`
+
+If running Raspbian, replace amd64 in the folder name shown above with armhf.
+
+Leosac has a number of additonal dependencies which need to be installed:
 ```
 sudo apt-get install cmake build-essential git \
 default-libmysqlclient-dev libtclap-dev libcurl4-openssl-dev libgtest-dev \
 libunwind-dev libzmq3-dev libpq-dev libpython2.7-dev libscrypt-dev \
 libsqlite3-dev libsodium-dev libssl-dev libboost-date-time-dev \
 libboost-filesystem-dev libboost-regex-dev libboost-serialization-dev \
-libboost-system-dev python3 python3-pip
+libboost-system-dev python3 python3-pip libodb-boost-dev libodb-mysql-dev \
+libodb-pgsql-dev libodb-sqlite-dev libodb-dev
 ```
 
-@note The ODB package from the Debian repository is broken. A bug report has been filed. See [889664](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=889664). Until this is resolved, a set of patched odb packages have been made available in the Leosac bin-resources repository
-
-The following steps assume there are not already any odb packages installed on the target system. If there are, uninstall them first.
-```
-git clone https://github.com/leosac/bin-resources
-cd bin-resources/debian/gcc6/amd64
-sudo dpkg -i *.deb
-sudo apt-get install -f
-```
-If running Raspbian, replace amd64 in the folder name shown above with armhf.
 
 Build
 -----
 
-Clone the repo: `git clone https://github.com/leosac/leosac.git`
-Now go to the `leosac` directory.
+Clone the repo and peform a legacy make install from-source:
+  + `git clone https://github.com/leosac/leosac.git`
+  + `cd leosac`
+  + `git submodule init && git submodule update`
+  + `mkdir build`
+  + `cd build`
+  + `cmake -DCMAKE_BUILD_TYPE=Release ..`
+  + `make`
+  + `sudo make install`
 
-```
-git submodule init && git submodule update
-mkdir build;
-cd build;
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make
-sudo make install
-```
 
 Follow-Up Tasks
 ---------------
 
-Leosac is now installed on your system, but there are couple of tasks you should perform.
+Leosac is now installed on your system, but there are couple of additional tasks you should perform.
 
-Copy the init script into place so that Leosac can be started as a service:
-```
-sed -i 's/\/usr\/bin\/leosac/\/usr\/local\/bin\/leosac/g' ../pkg/deb/leosacd
-sudo install -m 755 -t "/etc/init.d" "../pkg/deb/leosacd"
-```
-The steps above assume you are still in the build subfolder created earlier.
+Edit the leosac service file, changing `/usr/bin/leosac` to `/usr/local/bin/leosac`, then copy it into place:
+  + `vi/gedit ../pkg/debian/leosac.service`
+  + `sudo cp ../pkg/debian/leosac.service /etc/systemd/system`
 
-Create a kernel.xml file (see the [installation guide](@ref page_guide_rpi_piface_wiegand)) and copy it to /etc/leosac.d.
-```
-sudo install -m 755 -d "/etc/leosac.d"
-```
+@note The steps above assume you are still in the build subfolder created earlier.
+
+Finally, before you can start Leosac, you need to create a kernel.xml file. See the [installation guide](@ref page_guide_rpi_piface_wiegand).
+


### PR DESCRIPTION
This PR does the following:
- fixes the issue with sed regex not rendering as mentioned elsewhere
- fixes a few typos from a previous pr
- makes the formatting of the three guides consistent between one another: docker-cc, leosac from source, and leosac from package