### PR TITLE
disable stacktrace when building release

### DIFF
--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -10,7 +10,8 @@ override_dh_shlibdeps:
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLEOSAC_STACKTRACE_DISABLED=1
 
 override_dh_systemd_start:
 	dh_systemd_start --no-start


### PR DESCRIPTION
When CMAKE_BUILD_TYPE=Release is set, debug symbols are intentionally removed from the build. 

However, leosac fills the log with many messages stating missing debug info:
```
[2018-02-12 13:08:40.724] [console] [error] [5076] Problem when generating stacktrace: no debug info in ELF executable. Error code: -1
```

Setting the LEOSAC_STACKTRACE_DISABLED flag in debian rules silences these warnings. 

NOTE: Perhaps we should set LEOSAC_STACKTRACE_DISABLED in CMakeLists.txt if CMAKE_BUILD_TYPE=Release.  If we build Release rather than Debug, I can't think of a case where we want to see ever these messages.
