### PR TITLE
deb.sh - make mk-build-deps noninteractive

### DIFF
--- a/deb.sh
+++ b/deb.sh
@@ -105,7 +105,9 @@ cd $name
 cp -R pkg/debian .
 
 # Auto-install build dependencies using the debian control file
-sudo mk-build-deps -ir ./debian/control
+sudo mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes \
+    --no-install-recommends --no-upgrade -y" \
+    ./debian/control
 
 if [ -z ${DEB_BUILD_OPTIONS} ] ; then
     export DEB_BUILD_OPTIONS="parallel=3"


### PR DESCRIPTION
My apologies for all the little pr's. I was rather spontaneous today.

This pr modifies the deb.sh script to not prompt for confirmation when installing package dependencies, thus making it scriptable inside a build environment.
 