### PR TITLE
Fix RPATH for non-cc builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ set(CPACK_PACKAGE_VERSION_PATCH "0")
 
 include(CPack)
 
-set(CMAKE_INSTALL_RPATH "\$ORIGIN/../lib")
+
+set(CMAKE_INSTALL_RPATH "\$ORIGN:\$ORIGIN/../lib/leosac")
 set(LEOSAC_CROSS_COMPILE 0)
 if (CMAKE_TOOLCHAIN_FILE)
     # a bit hacky -- if a toolchain file si present, assume
@@ -26,7 +27,7 @@ if (CMAKE_TOOLCHAIN_FILE)
 
     # Set RPATH to "binary directory" (for dev mode) and "/opt/rpi_faekroot"
     # for "installed" mode
-    set(CMAKE_INSTALL_RPATH "/opt/rpi_fakeroot/lib:\$ORIGIN:${CMAKE_INSTALL_RPATH}")
+    set(CMAKE_INSTALL_RPATH "/opt/rpi_fakeroot/lib:${CMAKE_INSTALL_RPATH}")
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CPACK_PACKAGE_VERSION_PATCH "0")
 
 include(CPack)
 
+set(CMAKE_INSTALL_RPATH "\$ORIGIN/../lib")
 set(LEOSAC_CROSS_COMPILE 0)
 if (CMAKE_TOOLCHAIN_FILE)
     # a bit hacky -- if a toolchain file si present, assume
@@ -25,7 +26,7 @@ if (CMAKE_TOOLCHAIN_FILE)
 
     # Set RPATH to "binary directory" (for dev mode) and "/opt/rpi_faekroot"
     # for "installed" mode
-    set(CMAKE_INSTALL_RPATH "/opt/rpi_fakeroot/lib:\$ORIGIN")
+    set(CMAKE_INSTALL_RPATH "/opt/rpi_fakeroot/lib:\$ORIGIN:${CMAKE_INSTALL_RPATH}")
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 endif ()
 
@@ -69,7 +70,6 @@ endif ()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${LEOSAC_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LEOSAC_BINARY_DIR})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${LEOSAC_BINARY_DIR})
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:\$ORIGIN/../lib")
 
 add_subdirectory(deps/zmqpp)
 add_subdirectory(src)


### PR DESCRIPTION
This is the last PR of the day. I promise!

This fixes the following fatal error when attempting to run Leosac 0.7.0 pre-release after building natively:
```
Creating Leosac Kernel...
...
[2018-02-12 19:11:38.185] [console] [info] [9921] Loading library at: /usr/local/lib/leosac/libpifacedigital.so
[2018-02-12 19:11:39.135] [console] [error] [9921] FAILURE, full path was:{/usr/local/lib/leosaclibpifacedigital.so}: DynLib::dlopen(): libwebsock-api.so: cannot open shared object file: No such file or directory
...
Aborted
```

