### PR TITLE
Add Wiegand AUTODETECT nowait flag

### DIFF
--- a/src/modules/wiegand/Wiegand.md
+++ b/src/modules/wiegand/Wiegand.md
@@ -35,6 +35,7 @@ readers      |          |             | Lists of all configured readers         
 --->         | --->     | mode        | Which mode the reader is using (see below)                 | NO (defaults to `SIMPLE_WIEGAND`)
 --->         | --->     | pin_timeout | Timeout when reading a PIN code.                           | NO (defaults to 2500ms)
 --->         | --->     | pin_key_end | Which key is used to signal the end of a PIN code          | NO (defaults to '#')
+--->         | --->     | nowait      | Don't wait for pin code after card read                    | NO (defaults to 0)
 
 **Note**: `high`, `low`, `green_led` and `buzzer` must be name of GPIO object: either defined using
 the sysfsgpio or pifacedigital module.
@@ -50,7 +51,7 @@ There are multiples `mode` available for a reader:
 7. `WIEGAND_CARD_PIN_BUFFERED` reads a card number followed by a PIN code read in buffered mode.
 8. `AUTODETECT` allows the module to read and create different type of credentials. It can read a pin code or a card number, or both.
 The pin code can be read if the reader is either in 4 bits or 8 bits mode. If you are doing card-only authentication,
-note that you will notice a delay of ~2second. This delay is here to let the user have a chance to enter his PIN code.
+note that you will notice a delay of ~2 second, unless nowait is set to true. This delay is here to let the user have a chance to enter his PIN code.
 
 @warning The `AUTODETECT` mode is not compatible with the hardware Wiegand-Buffered mode.
 

--- a/src/modules/wiegand/WiegandConfig.hpp
+++ b/src/modules/wiegand/WiegandConfig.hpp
@@ -48,7 +48,8 @@ struct WiegandReaderConfig : public Hardware::RFIDReader
     WiegandReaderConfig()
         : mode("SIMPLE_WIEGAND")
         , pin_timeout(2500)
-        , pin_key_end('#'){};
+        , pin_key_end('#')
+        , nowait(0){};
 
     WiegandReaderConfig(const WiegandReaderConfig &) = default;
 
@@ -96,6 +97,7 @@ struct WiegandReaderConfig : public Hardware::RFIDReader
 
     std::chrono::milliseconds pin_timeout;
     char pin_key_end;
+    bool nowait;
 
     /**
      * List of valid operation mode for a reader.

--- a/src/modules/wiegand/strategies/Autodetect.cpp
+++ b/src/modules/wiegand/strategies/Autodetect.cpp
@@ -25,13 +25,14 @@ using namespace Leosac::Module::Wiegand;
 using namespace Leosac::Module::Wiegand::Strategy;
 
 Autodetect::Autodetect(WiegandReaderImpl *reader, std::chrono::milliseconds delay,
-                       char pin_key_end)
+                       char pin_key_end, bool nowait)
     : WiegandStrategy(reader)
     , delay_(delay)
     , reading_pin_(false)
     , reading_card_(true)
     , ready_(false)
     , pin_key_end_(pin_key_end)
+    , nowait_(nowait)
 {
     time_card_read_ = std::chrono::system_clock::now();
     last_pin_read_  = std::chrono::system_clock::now();
@@ -114,7 +115,7 @@ void Autodetect::check_timeout()
         }
     }
     // 2 sec of total inactivity and we valid card.
-    if (elapsed_ms > delay_ && elapsed_ms_pin > delay_)
+    if ((elapsed_ms > delay_ && elapsed_ms_pin > delay_) || nowait_)
     {
         if (read_card_strategy_->completed() && read_card_strategy_->get_nb_bits())
         {

--- a/src/modules/wiegand/strategies/Autodetect.hpp
+++ b/src/modules/wiegand/strategies/Autodetect.hpp
@@ -52,7 +52,7 @@ class Autodetect : public WiegandStrategy
     * @param pin_key_end    what key on the reader signals the end of the pin code ?
     */
     Autodetect(WiegandReaderImpl *reader, std::chrono::milliseconds delay,
-               char pin_key_end);
+               char pin_key_end, bool nowait);
 
     virtual void timeout() override;
 
@@ -100,6 +100,7 @@ class Autodetect : public WiegandStrategy
     bool ready_;
 
     char pin_key_end_;
+    bool nowait_;
 };
 }
 }

--- a/src/modules/wiegand/wiegand.cpp
+++ b/src/modules/wiegand/wiegand.cpp
@@ -183,7 +183,7 @@ WiegandReaderModule::create_strategy(const WiegandReaderConfig &reader_cfg,
     else if (reader_cfg.mode == "AUTODETECT")
     {
         return std::unique_ptr<WiegandStrategy>(
-            new Autodetect(reader, reader_cfg.pin_timeout, reader_cfg.pin_key_end));
+            new Autodetect(reader, reader_cfg.pin_timeout, reader_cfg.pin_key_end, reader_cfg.nowait));
     }
     else
     {
@@ -274,6 +274,7 @@ void WiegandReaderModule::load_xml_config(
         reader_config->pin_timeout =
             std::chrono::milliseconds(xml_reader_cfg.get<int>("pin_timeout", 2500));
         reader_config->pin_key_end = xml_reader_cfg.get<char>("pin_key_end", '#');
+        reader_config->nowait = xml_reader_cfg.get<bool>("nowait", 0);
 
         config_check(reader_config->gpio_low_name(),
                      ConfigChecker::ObjectType::GPIO);


### PR DESCRIPTION
Per design, the Wiegand module AUTODETECT mode waits ~2 seconds after a card read, to give the cardholder a chance to enter his/her pin.

This PR allows the sys admin to optionally set `<nowait>true</nowait>`. With this flag enabled, card reads are processed immediately without a delay. Naturally, it is not possible to enter a pin code following a card read with this flag enabled, but some will consider this a fair trade off.

I am currently testing this feature on my Pi Zero and it is working as expected.

I do not currently understand how odb builds schema files from the code (seems like pure magic) so please let me know if I have overlooked something related to that.

