### PR TITLE
Additional cmake checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ set(CPACK_PACKAGE_VERSION_MINOR "7")
 set(CPACK_PACKAGE_VERSION_PATCH "0")
 
 include(CPack)
-include (CheckIncludeFile)
 
 set(CMAKE_INSTALL_RPATH "\$ORIGN:\$ORIGIN/../lib/leosac")
 set(LEOSAC_CROSS_COMPILE 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CPACK_PACKAGE_VERSION_MINOR "7")
 set(CPACK_PACKAGE_VERSION_PATCH "0")
 
 include(CPack)
-
+include (CheckIncludeFile)
 
 set(CMAKE_INSTALL_RPATH "\$ORIGN:\$ORIGIN/../lib/leosac")
 set(LEOSAC_CROSS_COMPILE 0)
@@ -51,6 +51,14 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 find_package(CXX11 REQUIRED)
 find_package(TCLAP REQUIRED)
 find_package(Boost 1.62 REQUIRED date_time system serialization regex filesystem)
+find_package(LibScrypt REQUIRED)
+find_package(PkgConfig REQUIRED)
+find_package(SQLite REQUIRED)
+find_package(CURL REQUIRED)
+find_package(OpenSSL REQUIRED)
+
+include_directories(${TCLAP_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${LIBSCRYPT_INCLUDE_DIR}
+                    ${SQLITE_INCLUDE_DIR} ${CURL_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
 
 # ODB stuff
 find_package(ODB REQUIRED COMPONENTS pgsql sqlite boost)

--- a/cmake/FindLibScrypt.cmake
+++ b/cmake/FindLibScrypt.cmake
@@ -1,0 +1,25 @@
+include(FindPackageHandleStandardArgs)
+
+if (LIBSCRYPT_INCLUDE_DIR AND LIBSCRYPT_LIBRARY)
+    set(LibScrypt_FIND_QUIETLY TRUE)
+
+else (LIBSCRYPT_INCLUDE_DIR AND LIBSCRYPT_LIBRARY)
+    set(LibScrypt_FIND_QUIETLY false)
+
+    find_path (LIBSCRYPT_INCLUDE_DIR
+      NAMES libscrypt.h
+      PATH_SUFFIXES include
+      DOC "LibScrypt include directory")
+
+    find_library (LIBSCRYPT_LIBRARY
+      NAMES scrypt
+      PATH_SUFFIXES lib
+      DOC "LibScrypt release library")
+
+endif (LIBSCRYPT_INCLUDE_DIR AND LIBSCRYPT_LIBRARY)
+
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibScrypt DEFAULT_MSG LIBSCRYPT_INCLUDE_DIR LIBSCRYPT_LIBRARY)
+mark_as_advanced (LIBSCRYPT_INCLUDE_DIR LIBSCRYPT_LIBRARY)
+
+

--- a/cmake/FindSQLite.cmake
+++ b/cmake/FindSQLite.cmake
@@ -1,0 +1,66 @@
+# - Try to find Sqlite
+# Once done this will define
+#
+#  SQLITE_FOUND - system has Sqlite
+#  SQLITE_INCLUDE_DIR - the Sqlite include directory
+#  SQLITE_LIBRARIES - Link these to use Sqlite
+#  SQLITE_DEFINITIONS - Compiler switches required for using Sqlite
+#
+# Copyright (c) 2008, Gilles Caulier, <caulier.gilles@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if ( SQLITE_INCLUDE_DIR AND SQLITE_LIBRARIES )
+   # in cache already
+   SET(Sqlite_FIND_QUIETLY TRUE)
+endif ( SQLITE_INCLUDE_DIR AND SQLITE_LIBRARIES )
+
+# use pkg-config to get the directories and then use these values
+# in the FIND_PATH() and FIND_LIBRARY() calls
+if( NOT WIN32 )
+  find_package(PkgConfig)
+
+  pkg_check_modules(PC_SQLITE sqlite3)
+
+  set(SQLITE_DEFINITIONS ${PC_SQLITE_CFLAGS_OTHER})
+endif( NOT WIN32 )
+
+FIND_PATH(SQLITE_INCLUDE_DIR NAMES sqlite3.h
+  PATHS
+  ${PC_SQLITE_INCLUDEDIR}
+  ${PC_SQLITE_INCLUDE_DIRS}
+)
+
+FIND_LIBRARY(SQLITE_LIBRARIES NAMES sqlite3
+  PATHS
+  ${PC_SQLITE_LIBDIR}
+  ${PC_SQLITE_LIBRARY_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Sqlite DEFAULT_MSG SQLITE_INCLUDE_DIR SQLITE_LIBRARIES )
+
+# show the SQLITE_INCLUDE_DIR and SQLITE_LIBRARIES variables only in the advanced view
+MARK_AS_ADVANCED(SQLITE_INCLUDE_DIR SQLITE_LIBRARIES )
+

--- a/doc/guides/guide_install_from_package.md
+++ b/doc/guides/guide_install_from_package.md
@@ -16,7 +16,7 @@ Dependencies
 ------------
 
 For starters, install these packages:
-  + `apt-get install cmake build-essential git sudo devscripts`
+  + `apt-get install cmake build-essential pkg-config git sudo devscripts`
 
 @note The ODB package in the Debian & Raspbian repositories is broken. A bug report has been filed. See [889664](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=889664). Until this is resolved, a set of patched odb packages have been made available in the Leosac [bin-resources](https://github.com/leosac/bin-resources) repository.
 

--- a/doc/guides/guide_install_from_source.md
+++ b/doc/guides/guide_install_from_source.md
@@ -26,7 +26,7 @@ If running Raspbian, replace amd64 in the folder name shown above with armhf.
 
 Leosac has a number of additonal dependencies which need to be installed:
 ```
-sudo apt-get install cmake build-essential git \
+sudo apt-get install cmake build-essential pkg-config git \
 default-libmysqlclient-dev libtclap-dev libcurl4-openssl-dev libgtest-dev \
 libunwind-dev libzmq3-dev libpq-dev libpython2.7-dev libscrypt-dev \
 libsqlite3-dev libsodium-dev libssl-dev libboost-date-time-dev \

--- a/docker/Dockerfile.main2
+++ b/docker/Dockerfile.main2
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y emacs25-nox wget
 
 ## General dependencies
 RUN apt-get update && apt-get install -y          \
-cmake build-essential git                         \
+cmake build-essential pkg-config git              \
 libssl-dev                                        \
 libcurl4-openssl-dev libtclap-dev libscrypt-dev   \
 libzmq3-dev                                       \

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -29,7 +29,8 @@ Build-Depends: debhelper (>= 9), dh-systemd,
                libodb-mysql-dev,
                libodb-pgsql-dev,
                libodb-sqlite-dev,
-               odb
+               odb,
+               pkg-config
 
 Package: leosac
 Architecture: any


### PR DESCRIPTION
This PR configures cmake to check for libscrypt, sqlite, curl, and openssl since header files from these libraries are required to build leosac 0.7.

This has been tested to build successfully using deb.sh and leosaccli/docker.
