### PR TITLE
Libgpiod Module Fixes

### DIFF
--- a/src/modules/libgpiod/CMakeLists.txt
+++ b/src/modules/libgpiod/CMakeLists.txt
@@ -12,7 +12,7 @@ set(LIBGPIOD_SRCS
 
 add_library(${LIBGPIOD_BIN} SHARED ${LIBGPIOD_SRCS})
 
-target_linked_libraries(${LIBGPIOD_BIN}
+target_link_libraries(${LIBGPIOD_BIN}
     PRIVATE
     PkgConfig::LIBGPIOD
 )

--- a/src/modules/libgpiod/CMakeLists.txt
+++ b/src/modules/libgpiod/CMakeLists.txt
@@ -1,3 +1,6 @@
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBGPIOD REQUIRED IMPORTED_TARGET libgpiod)
+
 set(LIBGPIOD_BIN libgpiod)
 
 set(LIBGPIOD_SRCS
@@ -8,6 +11,11 @@ set(LIBGPIOD_SRCS
 )
 
 add_library(${LIBGPIOD_BIN} SHARED ${LIBGPIOD_SRCS})
+
+target_linked_libraries(${LIBGPIOD_BIN}
+    PRIVATE
+    PkgConfig::LIBGPIOD
+)
 
 set_target_properties(${LIBGPIOD_BIN} PROPERTIES
     COMPILE_FLAGS "${MODULE_COMPILE_FLAGS}"

--- a/src/modules/libgpiod/LibgpiodPin.cpp
+++ b/src/modules/libgpiod/LibgpiodPin.cpp
@@ -176,7 +176,7 @@ void LibgpiodPin::register_sockets(zmqpp::reactor *reactor)
         gpiod_fd_ = gpiod_line_event_get_fd(gpiod_line_);
         ASSERT_LOG(gpiod_fd_ >= 0, "Bad GPIO line or the line is not setup for event monitoring.");
         reactor->add(gpiod_fd_, std::bind(&LibgpiodPin::handle_interrupt, this),
-                     zmqpp::poller::poll_pri);
+                     zmqpp::poller::poll_in);
     }
 }
 

--- a/src/modules/libgpiod/LibgpiodPin.cpp
+++ b/src/modules/libgpiod/LibgpiodPin.cpp
@@ -47,8 +47,7 @@ LibgpiodPin::LibgpiodPin(zmqpp::context &ctx, const std::string &name, const std
     gpiod_line_ = gpiod_chip_get_line(gpiod_chip_, gpio_offset_);
     assert(gpiod_line_ != nullptr);
 
-    set_direction(direction);
-    set_interrupt(interrupt_mode);
+    configure_line(direction, interrupt_mode);
 }
 
 LibgpiodPin::~LibgpiodPin()
@@ -68,16 +67,17 @@ void LibgpiodPin::release()
   }
 }
 
-void LibgpiodPin::set_direction(Direction dir)
+void LibgpiodPin::configure_line(Direction dir, InterruptMode mode)
 {
-    if (dir == Direction::In)
-    {
-      gpiod_line_request_input(gpiod_line_, module_.general_config()->consumer().c_str());
-    }
-    else
-    {
-      gpiod_line_request_output(gpiod_line_, module_.general_config()->consumer().c_str(), initial_value_);
-    }
+  if (gpiod_line_) {
+    gpiod_line_release(gpiod_line_);
+  }
+
+  if (dir == Direction::Out) {
+    gpiod_line_request_output(gpiod_line_, module_.general_config()->consumer().c_str(), initial_value_);
+  } else {
+    set_interrupt(mode);
+  }
 }
 
 void LibgpiodPin::set_interrupt(InterruptMode mode)

--- a/src/modules/libgpiod/LibgpiodPin.hpp
+++ b/src/modules/libgpiod/LibgpiodPin.hpp
@@ -124,9 +124,9 @@ class LibgpiodPin
     void handle_message();
 
     /**
-    * Write direction to the `direction` file.
+    * Configure the line with direction to output or set interrupt mode.
     */
-    void set_direction(Direction dir);
+    void configure_line(Direction dir, InterruptMode mode);
 
     /**
     * Write interrupt mode to the `edge` file.


### PR DESCRIPTION
The libgpiod was not working due to linking errors, requesting the same gpio line multiple times (after being reserved) and using the incorrect interrupt type. This PR attempts to fix these by linking the libgpiod package, requesting only one GPIO line based off of the direction and interrupt mode, and updates the interrupt type to poll_in as opposed to poll_pri.