### PR TITLE
Fixed deb.sh after repo name change

### DIFF
--- a/deb.sh
+++ b/deb.sh
@@ -22,8 +22,8 @@ function die()
 
 function clone()
 {
-    git clone $1
-    pushd access-control
+    git clone $1 leosac
+    pushd leosac
     git checkout $2;
     git submodule init;
     git submodule update;

--- a/deb.sh
+++ b/deb.sh
@@ -23,7 +23,7 @@ function die()
 function clone()
 {
     git clone $1
-    pushd leosac
+    pushd access-control
     git checkout $2;
     git submodule init;
     git submodule update;


### PR DESCRIPTION
The build fails using the deb.sh file after the repo name change, as it tries to cd into leosac when the directory is cloned as access-control